### PR TITLE
Add operator< to Vec2

### DIFF
--- a/src/jngl/Vec2.hpp
+++ b/src/jngl/Vec2.hpp
@@ -8,6 +8,7 @@
 #include <boost/version.hpp>
 #endif
 #include <iosfwd>
+#include <tuple>
 
 namespace jngl {
 
@@ -53,6 +54,12 @@ public:
 	template <class Archive> void serialize(Archive& ar, const unsigned int) {
 		ar(x, y);
 	}
+
+	bool operator<(const Vec2& rhs) const
+	{
+        return std::tie(x, y) < std::tie(rhs.x, rhs.y);
+    }
+
 };
 
 } // namespace jngl


### PR DESCRIPTION
So Vec2 can be used as key in std::map