### PR TITLE
Use OpenAL Soft on iOS instead of Apple's OpenAL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -252,18 +252,25 @@ else()
 		set(OPENAL_LIBRARY OpenAL)
 
 	elseif(IOS)
-		target_compile_options(jngl PRIVATE -Wno-deprecated-declarations) # OpenAL
+		# target_compile_options(jngl PRIVATE -Wno-deprecated-declarations) # OpenAL
 		target_compile_definitions(jngl PRIVATE IOS)
 		target_compile_definitions(jngl PUBLIC GLES_SILENCE_DEPRECATION)
 		target_include_directories(jngl PUBLIC include/ios)
 		find_library(IOS_OPENGLES OpenGLES)
-		find_library(IOS_OPENAL OpenAL)
+
+		include(cmake/CPM.cmake)
+		CPMAddPackage(NAME openal
+			URL https://github.com/kcat/openal-soft/archive/refs/tags/1.21.1.zip
+			URL_HASH SHA1=1442363faf47a5a7cd6287513068ecd6c70e747e
+			OPTIONS "LIBTYPE STATIC" "HAVE_LIBLOG 0")
+		# set(IOS_OPENAL OpenAL)
+
 		find_library(IOS_QUARTZCORE QuartzCore)
 		find_library(IOS_UIKIT UIKit)
 		find_library(IOS_AVFOUNDATION AVFoundation)
 		find_library(IOS_GAMECONTROLLER GameController)
 		target_link_libraries(jngl PRIVATE
-			${IOS_OPENGLES} ${IOS_OPENAL} ${IOS_QUARTZCORE} ${IOS_UIKIT} ${IOS_AVFOUNDATION}
+			${IOS_OPENGLES} OpenAL ${IOS_QUARTZCORE} ${IOS_UIKIT} ${IOS_AVFOUNDATION}
 			${IOS_GAMECONTROLLER}
 		)
 

--- a/src/SoundParams.hpp
+++ b/src/SoundParams.hpp
@@ -2,13 +2,8 @@
 // For conditions of distribution and use, see copyright notice in LICENSE.txt
 #pragma once
 
-#ifdef __APPLE__
-#include <OpenAL/al.h>
-#include <OpenAL/alc.h>
-#else
 #include <AL/al.h>
 #include <AL/alc.h>
-#endif
 #define OV_EXCLUDE_STATIC_CALLBACKS
 #include <vorbis/vorbisfile.h>
 

--- a/src/jngl/Video.cpp
+++ b/src/jngl/Video.cpp
@@ -18,14 +18,10 @@
 #include "sound.hpp"
 #include "time.hpp"
 
+#include <AL/al.h>
 #include <algorithm>
 #include <boost/numeric/conversion/cast.hpp>
 #include <deque>
-#ifdef __APPLE__
-#include <OpenAL/al.h>
-#else
-#include <AL/al.h>
-#endif
 
 namespace jngl {
 

--- a/src/test/test.cpp
+++ b/src/test/test.cpp
@@ -36,7 +36,7 @@ public:
 		factor = std::sin(rotate / 360 * boost::math::constants::pi<double>());
 		logoWebp.setPos(-logoWebp.getWidth() * factor, -logoWebp.getHeight() * factor);
 		volume += static_cast<float>(jngl::getMouseWheel()) / 100.0f;
-		if (jngl::keyPressed('p')) {
+		if (jngl::keyPressed('p') || jngl::mousePressed()) {
 			jngl::stop("test.ogg");
 			jngl::play("test.ogg");
 		}
@@ -132,7 +132,7 @@ public:
 			jngl::setFullscreen(!jngl::getFullscreen());
 		}
 		jngl::print("Press K to test key codes.", 5, 490);
-		jngl::print("Press P to play a sound.", 6, 510);
+		jngl::print("Press P or touch to play a sound.", 6, 510);
 		static int playbackSpeed = 100;
 		jngl::setPlaybackSpeed(float(playbackSpeed) / 100.0f);
 		jngl::print("Press + and - to change the audio playback speed: " +


### PR DESCRIPTION
Not needed until Apple removes OpenAL (still works fine on iOS 15).