### PR TITLE
iOS: Fix deprecation warning for openURL

### DIFF
--- a/src/ios/other.mm
+++ b/src/ios/other.mm
@@ -21,7 +21,8 @@ std::string getPreferredLanguage() {
 
 void openURL(const std::string& url) {
 	[[UIApplication sharedApplication]
-	    openURL:[NSURL URLWithString:[NSString stringWithUTF8String:url.c_str()]]];
+	    openURL:[NSURL URLWithString:[NSString stringWithUTF8String:url.c_str()]]
+     options:@{} completionHandler:nil ];
 }
 
 void errorMessage(const std::string& text) {


### PR DESCRIPTION
Haven't seen the warning in a while, but I was sure that it was there. Not sure if this fixes it though.