### PR TITLE
web: switch Emscripten build to GLES3/WebGL2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Emscripten")
 	# emcc: error: sdl3 port is still experimental [-Wexperimental] [-Werror]
 	string(APPEND CMAKE_CXX_FLAGS " ${USE_FLAGS} -sNO_DISABLE_EXCEPTION_CATCHING -Wno-experimental")
 	string(APPEND CMAKE_C_FLAGS " ${USE_FLAGS} -Wno-experimental")
-	string(APPEND CMAKE_EXE_LINKER_FLAGS " ${USE_FLAGS} -sASSERTIONS=1 --preload-file data")
+	string(APPEND CMAKE_EXE_LINKER_FLAGS " ${USE_FLAGS} -sASSERTIONS=1 -sMIN_WEBGL_VERSION=2 -sMAX_WEBGL_VERSION=2 --preload-file data")
 	set(CMAKE_EXECUTABLE_SUFFIX ".html")
 endif()
 

--- a/src/opengl.hpp
+++ b/src/opengl.hpp
@@ -16,16 +16,7 @@
 		#include <GLES3/gl3ext.h>
 	#else
 		#ifdef __EMSCRIPTEN__
-			#define GL_GLEXT_PROTOTYPES 1
-			#include <GLES2/gl2.h>
-			#include <GLES2/gl2ext.h>
-
-			#define glGenVertexArrays glGenVertexArraysOES
-			#define glBindVertexArray glBindVertexArrayOES
-			#define glDeleteVertexArrays glDeleteVertexArraysOES
-			#define GL_RGBA8 GL_RGBA8_OES
-			#define GL_HALF_FLOAT GL_HALF_FLOAT_OES
-			#define GL_RGBA16F GL_RGBA16F_EXT
+			#include <GLES3/gl3.h>
 		#else
 			#include <glad/gl.h>
 		#endif


### PR DESCRIPTION
Use core GLES3 headers for the web target instead of GLES2 with OES/EXT shims. This provides GL_HALF_FLOAT, GL_RGBA16F, GL_RGBA8 and VAO functions as core symbols, and is the correct target for HDR FrameBuffers (RGBA16F renderbuffers are reliably color-renderable on WebGL2). Requires a WebGL2 context via -sMIN/MAX_WEBGL_VERSION=2, dropping WebGL1 support.